### PR TITLE
Add news article for Dr. Tobias Pfennig's PhD defense

### DIFF
--- a/src/md/news/2026-06-01-defense.md
+++ b/src/md/news/2026-06-01-defense.md
@@ -1,0 +1,21 @@
+---
+title: "Congratulations to Dr. Tobias Pfennig"
+description: "Congratulations to Dr. Tobias Pfennig"
+categories:
+  - news
+date: '2026-06-01'
+author: "Anna Matuszynska"
+published: true
+---
+
+**Congratulations to Dr. Tobias Pfennig**
+
+On 1 June 2026, Tobias Pfennig successfully defended his PhD thesis on computational modelling of photosynthesis in cyanobacteria. His research was funded by [Cluster of Excellence on Plant Sciences (CEPLAS)](https://www.ceplas.eu/).
+
+Tobias was the first PhD student in our lab and played a formative role in building it from the ground up. His doctoral work combined mathematical modelling, experimental data, and photosynthesis research to better understand the dynamics of cyanobacterial photosynthetic electron flow. A major outcome of this work was the first wavelength-dependent mathematical model of photosynthesis in Synechocystis sp. PCC 6803, published in *PLOS Computational Biology*.
+
+During his PhD, Tobias contributed to five scientific papers, presented his work internationally, and helped train students in computational modelling, including through CEPLAS-supported activities in Sub-Saharan Africa. His work reflects exactly the kind of interdisciplinary, quantitative biology that our lab develops.
+
+We are very proud of what he has achieved and delighted to see him reach this milestone.
+
+Congratulations, Dr. Tobias Pfennig!


### PR DESCRIPTION
Added a news article congratulating Dr. Tobias Pfennig on his PhD defense and detailing his research contributions.